### PR TITLE
Texture spoofing

### DIFF
--- a/src/main/java/ch/njol/unofficialmonumentamod/UnofficialMonumentaModClient.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/UnofficialMonumentaModClient.java
@@ -6,6 +6,7 @@ import ch.njol.unofficialmonumentamod.features.discordrpc.DiscordRPC;
 import ch.njol.unofficialmonumentamod.features.effect.EffectMoveScreen;
 import ch.njol.unofficialmonumentamod.features.effect.EffectOverlay;
 import ch.njol.unofficialmonumentamod.features.locations.Locations;
+import ch.njol.unofficialmonumentamod.features.spoof.TextureSpoofer;
 import ch.njol.unofficialmonumentamod.features.strike.ChestCountOverlay;
 import ch.njol.unofficialmonumentamod.features.strike.OverlayMoveScreen;
 import ch.njol.unofficialmonumentamod.features.misc.managers.Notifier;
@@ -53,6 +54,7 @@ public class UnofficialMonumentaModClient implements ClientModInitializer {
 
 
 	public static Locations locations = new Locations();
+	public static TextureSpoofer spoofer = new TextureSpoofer();
 
 	public static DiscordRPC discordRPC = new DiscordRPC();
 
@@ -119,6 +121,7 @@ public class UnofficialMonumentaModClient implements ClientModInitializer {
 		Notifier.onDisconnect();
 		LocationNotifier.onDisconnect();
 		locations.onDisconnect();
+		spoofer.onDisconnect();
 	}
 
 	public static boolean isOnMonumenta() {

--- a/src/main/java/ch/njol/unofficialmonumentamod/features/spoof/TextureSpoofer.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/features/spoof/TextureSpoofer.java
@@ -1,5 +1,6 @@
 package ch.njol.unofficialmonumentamod.features.spoof;
 
+import ch.njol.unofficialmonumentamod.UnofficialMonumentaModClient;
 import ch.njol.unofficialmonumentamod.mixins.item.ItemStackAccessor;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -10,7 +11,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtInt;
-import net.minecraft.nbt.NbtString;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
@@ -35,6 +35,7 @@ public class TextureSpoofer {
     }
 
     public ItemStack apply(ItemStack stack) {
+        if (!UnofficialMonumentaModClient.options.enableTextureSpoofing) return stack;
         String key = stack.getName().getString().toLowerCase();
         //probably, just probably should make it, so it's just the render and not the actual item that's edited, because it being able to be placed, does do stupid things.
         if (spoofedItems.containsKey(key)) {

--- a/src/main/java/ch/njol/unofficialmonumentamod/features/spoof/TextureSpoofer.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/features/spoof/TextureSpoofer.java
@@ -1,0 +1,163 @@
+package ch.njol.unofficialmonumentamod.features.spoof;
+
+import ch.njol.unofficialmonumentamod.mixins.item.ItemStackAccessor;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.reflect.TypeToken;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtInt;
+import net.minecraft.nbt.NbtString;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class TextureSpoofer {
+    private static final String CACHE_PATH = "monumenta/texture-spoof.json";
+    private final HashMap<String, SpoofItem> spoofedItems = new HashMap<>();
+    //need to change nbt / item
+
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .excludeFieldsWithoutExposeAnnotation()
+            .create();
+
+    public void onDisconnect() {
+        save();
+    }
+
+    public ItemStack apply(ItemStack stack) {
+        String key = stack.getName().getString().toLowerCase();
+        //probably, just probably should make it, so it's just the render and not the actual item that's edited, because it being able to be placed, does do stupid things.
+        if (spoofedItems.containsKey(key)) {
+            SpoofItem item = spoofedItems.get(key);
+            if (stack.hasNbt() && stack.getSubNbt("monumenta-mod.edited") != null) {
+                return stack;
+            }
+            if (item == null) {
+                //if I do dumb shit again, this should stop it from doing dumb shit
+                return stack;
+            }
+            ((ItemStackAccessor) (Object) stack).setItem(Registry.ITEM.get(item.getItemIdentifier()));
+
+            if (stack.hasNbt()) {
+                assert stack.getNbt() != null;
+                if (item.displayName != null) {
+                    stack.getNbt().put("plain", setPlain(stack.getNbt(), item.displayName));
+                }
+                //to be able to detect already edited stacks
+                NbtCompound monumentamodCompound = new NbtCompound();
+                monumentamodCompound.put("edited", NbtInt.of(1));
+                stack.getNbt().put("monumenta-mod", monumentamodCompound);
+            }
+        }
+        return stack;
+    }
+
+    private final TypeToken<HashMap<String, SpoofItem>> typeToken = new TypeToken<>(){};
+
+    private static NbtCompound setPlain(NbtCompound stackData, String displayName) {
+        NbtCompound plain = getOrCreateCompound(stackData, "plain");
+        NbtCompound display = getOrCreateCompound(plain, "display");
+        display.putString("Name", displayName);
+        plain.put("display", display);
+        return plain;
+    }
+
+    public static String getPlainDisplayName(NbtCompound stackData) {
+        try {
+            if (stackData.contains("plain")) {
+                if (stackData.getCompound("plain").contains("display")) {
+                    return stackData.getCompound("plain").getCompound("display").getString("Name");
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    private static NbtCompound getOrCreateCompound(NbtCompound compound, String key) {
+        if (compound.getCompound(key) == null) {
+            return new NbtCompound();
+        } else {
+            return compound.getCompound(key);
+        }
+    }
+
+    public static boolean hasBeenEdited(ItemStack stack) {
+        if (stack.hasNbt()) {
+            assert stack.getNbt() != null;
+            if (stack.getNbt().contains("monumenta-mod", 10)) {
+                return stack.getNbt().getCompound("monumenta-mod").getInt("edited") == 1;
+            }
+        }
+        return false;
+    }
+
+    public void load() {
+        File file = FabricLoader.getInstance().getConfigDir().resolve(CACHE_PATH).toFile();
+        if (!file.exists()) {
+            return;
+        }
+
+        try (FileReader reader = new FileReader(file)) {
+            HashMap<String, SpoofItem> loadedItems = GSON.fromJson(reader, typeToken.getType());
+            if  (loadedItems != null) {
+                spoofedItems.clear();
+                spoofedItems.putAll(loadedItems);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void save() {
+        File file = FabricLoader.getInstance().getConfigDir().resolve(CACHE_PATH).toFile();
+
+        if (!file.exists()) {
+            try {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(GSON.toJson(spoofedItems));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static class SpoofItem {
+        @Expose
+        public String item;
+        @Expose
+        public String displayName;
+
+        public SpoofItem(Item item, String displayName) {
+            this.item = Registry.ITEM.getId(item).toString();
+            this.displayName = displayName;
+        }
+
+        public Identifier getItemIdentifier() {
+            return new Identifier(item);
+        }
+
+        @Override
+        public String toString() {
+            return item + "-" + displayName;
+        }
+    }
+}

--- a/src/main/java/ch/njol/unofficialmonumentamod/mc/MonumentaModResourceReloader.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/mc/MonumentaModResourceReloader.java
@@ -15,6 +15,7 @@ public class MonumentaModResourceReloader implements SynchronousResourceReloader
     public void reload(ResourceManager manager) {
         UnofficialMonumentaModClient.LOGGER.info("Loading " + getName());
         UnofficialMonumentaModClient.locations.load();
+        UnofficialMonumentaModClient.spoofer.load();
         UnofficialMonumentaModClient.LOGGER.info("Finished loading " + getName());
     }
 

--- a/src/main/java/ch/njol/unofficialmonumentamod/mixins/ArmorFeatureRendererMixin.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/mixins/ArmorFeatureRendererMixin.java
@@ -23,6 +23,7 @@ import net.minecraft.util.math.Vec3f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ArmorFeatureRenderer.class)
@@ -74,6 +75,11 @@ public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extend
 		MinecraftClient.getInstance().getItemRenderer().renderItem(itemStack, ModelTransformation.Mode.HEAD,
 			false, matrices, vertexConsumers, i, OverlayTexture.DEFAULT_UV, headModel);
 		matrices.pop();
+	}
+
+	@ModifyVariable(method = "renderArmor", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;"))
+	private ItemStack editStack(ItemStack value) {
+		return UnofficialMonumentaModClient.spoofer.apply(value);
 	}
 
 }

--- a/src/main/java/ch/njol/unofficialmonumentamod/mixins/BlockItemMixin.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/mixins/BlockItemMixin.java
@@ -2,17 +2,19 @@ package ch.njol.unofficialmonumentamod.mixins;
 
 import ch.njol.unofficialmonumentamod.UnofficialMonumentaModClient;
 import ch.njol.unofficialmonumentamod.Utils;
+import ch.njol.unofficialmonumentamod.features.spoof.TextureSpoofer;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ShulkerBoxBlock;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.ItemPlacementContext;
-import net.minecraft.item.ItemStack;
+import net.minecraft.item.*;
+import net.minecraft.util.ActionResult;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Arrays;
 
@@ -37,6 +39,13 @@ public abstract class BlockItemMixin {
 			return;
 		}
 		itemStack.decrement(amount);
+	}
+
+	@Inject(method = "useOnBlock", at= @At("HEAD"), cancellable = true)
+	public void stopEditedItemPlacing(ItemUsageContext context, CallbackInfoReturnable<ActionResult> cir) {
+		if (TextureSpoofer.hasBeenEdited(context.getStack())) {
+			cir.setReturnValue(ActionResult.PASS);
+		}
 	}
 
 	/**

--- a/src/main/java/ch/njol/unofficialmonumentamod/mixins/ItemRendererMixin.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/mixins/ItemRendererMixin.java
@@ -12,10 +12,12 @@ import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.render.model.json.Transformation;
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.Vec3f;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -25,6 +27,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(ItemRenderer.class)
@@ -99,5 +102,10 @@ public abstract class ItemRendererMixin {
             }
         }
         return modelTransformation.getTransformation(renderMode);
+    }
+
+    @ModifyVariable(method = "getModel", at = @At("HEAD"), argsOnly = true)
+    private ItemStack editStack(ItemStack value) {
+        return UnofficialMonumentaModClient.spoofer.apply(value);
     }
 }

--- a/src/main/java/ch/njol/unofficialmonumentamod/mixins/item/ItemStackAccessor.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/mixins/item/ItemStackAccessor.java
@@ -1,0 +1,14 @@
+package ch.njol.unofficialmonumentamod.mixins.item;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ItemStack.class)
+public interface ItemStackAccessor {
+    @Mutable
+    @Accessor("item")
+    void setItem(Item item);
+}

--- a/src/main/java/ch/njol/unofficialmonumentamod/mixins/item/ItemStackMixin.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/mixins/item/ItemStackMixin.java
@@ -1,0 +1,28 @@
+package ch.njol.unofficialmonumentamod.mixins.item;
+
+import ch.njol.unofficialmonumentamod.UnofficialMonumentaModClient;
+import ch.njol.unofficialmonumentamod.features.spoof.TextureSpoofer;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Mixin(ItemStack.class)
+public class ItemStackMixin {
+    @Inject(method = "getTooltip", at = @At(value = "INVOKE_ASSIGN", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0), locals = LocalCapture.CAPTURE_FAILSOFT)
+    private void onTooltip(@Nullable PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, List<Text> list) {
+        if (TextureSpoofer.hasBeenEdited((ItemStack)(Object) this)) {
+            list.add(new LiteralText("Spoofed: " + TextureSpoofer.getPlainDisplayName(((ItemStack)(Object)this).getNbt())).formatted(Formatting.DARK_GRAY));
+        }
+    }
+}

--- a/src/main/java/ch/njol/unofficialmonumentamod/options/Options.java
+++ b/src/main/java/ch/njol/unofficialmonumentamod/options/Options.java
@@ -75,6 +75,9 @@ public class Options {
 	@Category("misc")
 	public boolean showCalculator = true;
 
+	@Category("misc")
+	public boolean enableTextureSpoofing = true;
+
 	@Category("abilities")
 	public transient DescriptionLine abilitiesDisplay_info;
 	@Category("abilities")

--- a/src/main/resources/assets/unofficial-monumenta-mod/lang/en_us.json
+++ b/src/main/resources/assets/unofficial-monumenta-mod/lang/en_us.json
@@ -118,5 +118,7 @@
   "unofficial-monumenta-mod.config.option.notifyLocation": "Shows a notification when leaving / joining a known area",
   "unofficial-monumenta-mod.config.option.notifyLocation.tooltip": "Whether or not it will render it.",
   "unofficial-monumenta-mod.config.option.notifierShowTime": "How long the notification stays on the screen",
-  "unofficial-monumenta-mod.config.option.notifierShowTime.tooltip": ""
+  "unofficial-monumenta-mod.config.option.notifierShowTime.tooltip": "",
+  "unofficial-monumenta-mod.config.option.enableTextureSpoofing": "Enable texture spoofing",
+  "unofficial-monumenta-mod.config.option.enableTextureSpoofing.tooltip": "Allows the ability to change the rendered texture of an item by tricking minecraft / optifine into believing that the item is another item."
 }

--- a/src/main/resources/unofficial-monumenta-mod.mixins.json
+++ b/src/main/resources/unofficial-monumenta-mod.mixins.json
@@ -14,14 +14,16 @@
     "MinecraftClientMixin",
     "PlayerListHudAccessor",
     "ThreadExecutorMixin",
+    "item.ItemStackAccessor",
+    "item.ItemStackMixin",
     "screen.ChatScreenMixin",
     "screen.HandledScreenAccessor"
   ],
   "client": [
-    "PlayerListHudMixin",
-    "screen.ScreenMixin",
     "PlayerListHudAccessor",
-    "ThreadExecutorMixin"
+    "PlayerListHudMixin",
+    "ThreadExecutorMixin",
+    "screen.ScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Texture spoofing in this case is just modifying the item's type and plain.display.Name values to trick optifine into rendering the CIT for the spoofed item.